### PR TITLE
docs: add comprehensive Chinese onboarding & maintenance guides for Unstable branch

### DIFF
--- a/docs/00_START_HERE.md
+++ b/docs/00_START_HERE.md
@@ -1,0 +1,56 @@
+# 00_START_HERE｜新维护者起步总览
+
+> 一句话摘要：先建立“入口 → 模块链 → 模式扩展点 → 运行时产物”的心智模型，再动代码。
+
+## 适合谁看
+- 第一次接触 `Unstable` 分支的 PHP 开发者。
+- 需要让 LLM/Agent 快速定位改动点的维护者。
+
+## 建议先读什么
+1. `docs/01_RUNTIME_FLOW.md`
+2. `docs/02_MODULE_SYSTEM.md`
+3. `docs/03_DIRECTORY_MAP.md`
+
+## 关键文件列表（最小必读）
+- `command.php`（统一命令入口 + daemon/client 分流）
+- `include/common.inc.php`（模块加载 + routine 触发）
+- `include/modules/modules.func.php`（模块钩子与 `import_module()`）
+- `gamedata/modules.list.php`（模块装配清单）
+- `include/valid.func.php`（玩家入场与卡片应用）
+- `include/pages/command_act.php`（游戏内动作处理）
+
+## 这个分支最重要的架构认知
+
+### 1) 这不是“单体 include 项目”，而是“模块链式覆写”项目
+这里的核心不是“找某个大函数改掉”，而是：
+- 一个函数名可被多个模块按依赖顺序覆盖；
+- 每层通过 `if (eval(__MAGIC__)) return $___RET_VALUE;` + `$chprocess(...)` 向下游链路传递；
+- 模块顺序来自 `gamedata/modules.list.php`，并受依赖关系校验。  
+
+### 2) `command.php` 既可能是 Web 请求处理器，也可能是 daemon server
+开启 `$___MOD_SRV` 后，同一个 `command.php` 会出现三种身份：
+- 启动 daemon 的“server 模式”；
+- 浏览器请求触发的“client 转发模式”；
+- daemon 内部 `include` 自己后执行的“真正业务执行模式”。
+
+### 3) “源码目录”和“运行/编译产物目录”必须区分
+- 源码主看：`include/modules/**`、`include/pages/**`、`templates/default/**`。
+- 运行/产物主看：`gamedata/run`、`gamedata/modinit`、`gamedata/templates`、`gamedata/tmp`。
+- 生产环境开启 ADV 后，业务执行可能来自 `gamedata/run`，不是直接跑 `include/modules`。
+
+## 新人最容易踩的坑
+1. **改了模块源码但页面没变化**：通常是忘了在 `modulemng.php` 重新编译（ADV/daemon 下必踩）。
+2. **把 `gamedata/tmp` 当源码读**：里面大量是运行时锁、socket、缓存、响应中间文件。
+3. **在技能/模块函数里漏写 `__MAGIC__` 开头**：会破坏钩子链。
+4. **在某模式写死逻辑但没加 `if ($gametype==X)`**：污染其他模式。
+5. **把 daemon 问题误判为业务 bug**：先确认是否走了 client->server 转发链。
+
+## 1~2 小时上手路线（建议）
+- 第 0~20 分钟：读 `command.php` + `include/common.inc.php`，掌握请求分流。
+- 第 20~50 分钟：读 `modules.func.php` + 任意 2~3 个模块 `module.inc.php`/`main.php`。
+- 第 50~80 分钟：读 `cardbase` + `valid.func.php`，理解“入场时效应注入”。
+- 第 80~120 分钟：读一个 gtype（如 `gtype1`）+ 一个 instance（如 `instance10_rogue`）。
+
+## 待确认 / 需要人工验证
+- 当前线上是否默认启用 `$___MOD_CODE_ADV2/$___MOD_SRV`：仓库里仅有 sample，实际配置在被 `.gitignore` 的本地文件中。
+- 某些旧注释提到“已废弃/已架空”函数，仍可能被历史页面或脚本调用，需在真实运行日志里确认。

--- a/docs/01_RUNTIME_FLOW.md
+++ b/docs/01_RUNTIME_FLOW.md
@@ -1,0 +1,113 @@
+# 01_RUNTIME_FLOW｜请求链路与运行时流程
+
+> 一句话摘要：从浏览器到 `command.php`，再到 `common.inc.php` 和模块链，最终落到 `include/pages/command_*.php`。
+
+## 适合谁看
+- 需要排查“请求到底跑到了哪里”的维护者。
+
+## 建议先读什么
+- `command.php`
+- `include/common.inc.php`
+- `include/pages/command_act.php`
+- `include/pages/command_game.php`
+
+## 关键文件列表
+- Web 入口：`game.php`、`index.php`、`chat.php` 等顶层脚本。
+- 命令中心：`command.php`。
+- 初始化：`include/common.inc.php`。
+- 页面脚本：`include/pages/command_*.php`。
+
+---
+
+## 1. Web 入口在哪里
+
+### 游戏页入口（展示页）
+`game.php` 做了两件事：
+1. 载入 `server.config.php` 以读取站点配置；
+2. `echo render_page('command_game')`，最终走到 `command.php` 的 `page=command_game` 分支。
+
+### 命令入口（AJAX）
+前端实际动作（移动、攻击、道具等）会命中 `command.php`，默认走 `command_act.php`。
+
+---
+
+## 2. `command.php` 的职责分层
+
+### A. daemon server 启动路径（`$_POST['command']='start'`）
+当传入连接密码和 `start` 时：
+- 定义 `IN_DAEMON`；
+- 立即返回 HTTP 200 给调用端，然后自己继续后台驻留；
+- 绑定本地随机端口，写 `gamedata/tmp/server/<port>/` 状态文件；
+- 循环监听 socket，请求到来后 `include ./command.php` 再执行业务分支。
+
+### B. client 转发路径（浏览器来请求，但当前脚本非 daemon 内部调用）
+开启 `$___MOD_SRV` 时：
+- 先 `NO_MOD_LOAD + NO_SYS_UPDATE` 轻量加载 `common.inc.php`；
+- 在 `gamedata/tmp/server` 选择可用 daemon；
+- 通过 `__SOCKET_SEND_TO_SERVER__()` 把请求发给 daemon；
+- 读取 daemon 结果返回浏览器。
+
+### C. 非 daemon 直跑路径（`$___MOD_SRV` 关闭）
+直接 `require include/common.inc.php`，然后进入页面分支执行。
+
+---
+
+## 3. 页面请求和命令请求如何分流
+
+`command.php` 末尾按 `$page` 分流：
+- `!isset($page) || $page=='command'` → `include/pages/command_act.php`（核心动作）
+- `page=command_game` → `include/pages/command_game.php`（进入游戏页初始渲染）
+- 其他 `command_valid/command_end/command_help/...` → 对应页面脚本。
+
+这解释了为什么“同一个 command.php”能同时服务动作与各种子页面。
+
+---
+
+## 4. `sys::routine()` 在什么阶段发生
+
+### 常规流程
+`include/common.inc.php` 在模块加载后会触发：
+- 若非 `chat/help`，且非 `news(sendmode=news)`，执行 `\sys\routine()`。
+
+### daemon 特判
+daemon 主循环里也有一次判断：
+- 非聊天新闻刷新（`sendmode != news`）时执行 `\sys\routine()`。
+
+> 实际效果：绝大多数请求在进业务逻辑前都先刷新全局游戏状态。
+
+---
+
+## 5. 玩家数据、地图数据、模板渲染在哪一层
+
+- 玩家数据：`player` 模块 (`fetch_playerdata/load_playerdata/player_save`)。
+- 地图与禁区节奏：`map` 模块（如 `get_area_wavenum/init_areatiming`）。
+- 模板渲染：`template.func.php`（模板编译）+ `template()`/`dump_template()` 调用点（集中在页面脚本和模块）。
+
+`command_act.php` 中：
+1. `load_playerdata` + `pre_act/act/post_act` 执行业务；
+2. `prepare_response_content` 和 `parse_interface_*` 组装前端更新块；
+3. `gencode($gamedata)` 返回 JSON。
+
+---
+
+## 6. 常见流程示例
+
+### 示例 A：玩家点击“攻击”
+1. 前端 POST 到 `command.php`。
+2. 若开启 daemon：client 选 daemon 并转发 socket。
+3. daemon 执行 `common.inc.php` → `sys::routine()` → `command_act.php`。
+4. `player::act()` 里分发到 battle/item 等模块。
+5. 返回编码后的 `gamedata` 给前端。
+
+### 示例 B：玩家打开游戏主界面
+1. `game.php` 调 `render_page('command_game')`。
+2. `command.php` 分到 `include/pages/command_game.php`。
+3. 载入玩家数据、聊天摘要、初始命令面板，输出 `template('game')`。
+
+## 新人最容易踩的坑
+- 误以为 `command_game` 和 `command_act` 是同一层：前者偏“初次渲染”，后者偏“动作执行”。
+- 调试 `routine` 时只盯一个入口：实际会在多个路径触发。
+- 在 daemon 下直接 `var_dump` 可能污染 socket 回包。
+
+## 待确认
+- 当前线上是否将 `render_page()` 统一走 `command.php` 渲染，还是存在直出模板的遗留入口（需结合部署环境验证）。

--- a/docs/02_MODULE_SYSTEM.md
+++ b/docs/02_MODULE_SYSTEM.md
@@ -1,0 +1,123 @@
+# 02_MODULE_SYSTEM｜模块系统本体（最重要）
+
+> 一句话摘要：本仓库通过 `modules.list + module.inc + __MAGIC__ + $chprocess` 构建可叠加覆写的模块链。
+
+## 适合谁看
+- 要新增/修改技能、模式、机制的人。
+
+## 建议先读什么
+1. `include/modules/modules.func.php`
+2. `include/modules/modules.init.template.php`
+3. `include/modulemng/modulemng.func.php`
+4. 任意模块的 `module.inc.php` 与 `main.php`
+
+## 关键文件列表
+- `gamedata/modules.list.php`
+- `include/modules/modules.func.php`
+- `include/modules/modules.init.template.php`
+- `include/modulemng/modulemng.func.php`
+- `include/modulemng/modulemng.config.sample.php`
+
+---
+
+## 1) `gamedata/modules.list.php` 是什么
+每行格式：
+`模块名, 模块路径, 是否启用(0/1)`
+
+例如：
+- `sys,core/sys/,1`
+- `cardbase,extra/card/cardbase/,1`
+- `instance10,extra/instance/instance10_rogue/,1`
+
+它决定：
+1. 哪些模块会被加载；
+2. 加载顺序（在依赖合法前提下非常关键）；
+3. 运行时 `MOD_XXX` 常量是否存在。
+
+---
+
+## 2) 标准模块结构
+标准模块目录通常包含：
+- `module.inc.php`：模块头信息（依赖、代码清单、模板清单）；
+- `main.php`：主体逻辑（钩子函数实现）；
+- `config/*.php`：配置数据；
+- `*.htm`：模块模板片段。
+
+### `module.inc.php` 头字段含义
+- `dependency`：硬依赖，必须存在。
+- `dependency_optional`：软依赖，存在则接链，不存在也可运行。
+- `conflict`：冲突模块。
+- `codelist`：本模块要加载的 php 文件列表。
+- `templatelist`：本模块模板基名列表（无需 `.htm` 后缀）。
+
+---
+
+## 3) `__INIT_MODULE__` 做了什么
+`module.inc.php` 末尾统一 `require __INIT_MODULE__(__NAMESPACE__,__DIR__)`。
+
+它会：
+- 生成/选择模块 init 文件（普通或 adv）；
+- 载入 `codelist` 文件；
+- 扫描并注册同名函数钩子链（`hook_register`）；
+- 生成 `IMPORT_MODULE_XXX_GLOBALS` 常量，供 `import_module()` 注入变量引用。
+
+---
+
+## 4) 命名空间约定与函数链
+- 模块名与 namespace 一致（如 `namespace skill71`）。
+- 可被覆写函数名在多模块中同名（如 `checkcombo`、`get_shopconfig`）。
+- 每个可覆写函数开头都要写：
+  `if (eval(__MAGIC__)) return $___RET_VALUE;`
+
+`__MAGIC__` 负责决定当前应调用的“下游函数” `$chprocess`，形成链式执行。
+
+---
+
+## 5) `import_module()` 的作用与风险
+
+### 作用
+`eval(import_module('sys','player'))` 会把模块内全局变量引用导入当前函数作用域，避免手写全局映射。
+
+### 风险
+1. 大量 `eval(import_module())` 在循环内会有性能负担（可改 `get_var_in_module()`）。
+2. daemon 下 `input` 模块有特殊逻辑，变量来自 `___LOCAL_INPUT__VARS__INPUT_VAR_LIST`，误用容易读到旧值。
+3. 在模块 `init()` 阶段导入 `sys/input` 有限制（modulemng 激活会检查）。
+
+---
+
+## 6) 钩子式/叠加式架构体现在哪
+
+### 典型模式
+- 基础模块给出默认实现（如 `cardbase::card_validate_get_forbidden_cards`）。
+- 模式模块按 `gametype` 条件覆写（如 `gtype1`、`instance10` 改卡片可用性）。
+- 调用 `$chprocess(...)` 继续传递，最终可形成“基础逻辑 + 模式补丁 + 活动补丁”。
+
+### 例子
+- `checkcombo()`：`instance0`、`gtype1`、`instance10` 都会按模式改连斗判定。
+- `get_shopconfig()`：多个 gtype/instance 按模式切换配置文件。
+- `card_validate_display()`：`cardbase` 默认 + `gtype1/instance10` 强制特定卡。
+
+---
+
+## 7) core / base / extra 分工
+- `core`：框架底座（输入、系统状态、玩家/地图主结构、主流程）。
+- `base`：常规玩法能力（战斗、道具、武器、探索、称号基础等）。
+- `extra`：扩展玩法（卡片、活动、实例模式、附加机制）。
+
+> 推荐思路：先在 `base` 找“公共能力”，再在 `extra` 找“模式化变体”。
+
+---
+
+## 8) 新人读模块的顺序建议
+1. 先读 `module.inc.php`（知道它依赖谁、改谁）。
+2. 再读 `main.php` 顶部 `init()`（知道注册了哪些常量/描述）。
+3. 再读关键被覆写函数。
+4. 最后看 `config` 与模板。
+
+## 新人最容易踩的坑
+- 只在一个模块里搜函数定义，没意识到同名函数链。
+- 新增函数忘写 `__MAGIC__`，导致断链。
+- 误把 `optional dependency` 当成必有模块，线上可能不存在。
+
+## 待确认
+- 当前线上是否启用 `CODE_ADV2/CODE_COMBINE`（会影响调试体验与报错栈）。

--- a/docs/03_DIRECTORY_MAP.md
+++ b/docs/03_DIRECTORY_MAP.md
@@ -1,0 +1,129 @@
+# 03_DIRECTORY_MAP｜目录地图（按“什么时候去看”组织）
+
+> 一句话摘要：优先区分“源码区/编译产物区/运行时区”，再按功能去找模块。
+
+## 适合谁看
+- 不知道该从哪个目录入手的维护者。
+
+## 建议先读什么
+- `docs/02_MODULE_SYSTEM.md`
+- 本文第 1、2、3 章
+
+## 关键文件列表
+- `include/modules/**`
+- `include/pages/**`
+- `gamedata/**`
+- `templates/default/**`
+
+---
+
+## 1) 顶层目录速览
+
+- `include/`：核心 PHP 源码（主战场）。
+- `gamedata/`：SQL、缓存、运行时、编译结果、录像与临时文件。
+- `templates/`：模板源码（默认包在 `templates/default`）。
+- 根目录脚本（`game.php`, `command.php`, `index.php`）：入口层。
+
+---
+
+## 2) `include/modules` 子体系
+
+### `core/`（底座/框架层）
+什么时候看：排“全局流程、玩家/地图基础状态、系统 routine、输入处理”问题。
+- `core/input`：输入变量注入。
+- `core/sys`：全局状态、gameinfo 读写、游戏开局/结束流程。
+- `core/player`：玩家数据池、锁、加载/保存。
+- `core/map`：地图与禁区基础。
+- `core/gameflow/*`：流程状态机（连斗、死斗、反挂机等）。
+
+### `base/`（基础玩法能力层）
+什么时候看：排“战斗/道具/探索/武器/常规技能”问题。
+- `base/battle`, `base/attack`, `base/weapon/*`
+- `base/itemmain`, `base/itemmix/*`, `base/items/*`
+- `base/skills/skill*`
+- `base/npc`, `base/explore`, `base/itemshop`
+
+### `extra/`（扩展玩法层）
+什么时候看：排“模式差异、活动、特殊系统”问题。
+- `extra/card/`：卡片系统与卡牌技能。
+- `extra/club/`：称号系统与称号技能。
+- `extra/instance/`：模式/实例（gtypeX + instanceX）
+- `extra/activities/`：活动类模块。
+- `extra/achievement/`：成就与奖励技能。
+- `extra/misc/`：杂项增强（bufficons、回放、天梯等）。
+
+---
+
+## 3) 重点子目录说明
+
+### `extra/card/`
+- `cardbase/`：卡配置、校验、入场卡效果应用、抽卡与能量。
+- `skills/skillXXX/`：卡片绑定技能。
+- `kujibase/`：抽卡相关入口（与 `kuji.php` 相关）。
+
+### `extra/club/`
+- `clubbase/`：称号可选列表、称号技能挂载、战斗技入口。
+- `clubs/clubX/`：称号本身定义。
+- `skills/skillXX/`：称号技能实现。
+
+### `extra/instance/`
+- `gtypeX/`：按 `gametype` 条件改写核心行为（偏“模式规则层”）。
+- `instanceX_.../`：具体实例玩法（偏“完整玩法包”）。
+- 常见包含 `config/*.php` + 专属 skill 模块。
+
+### `skills` / `attr` / `misc`（横切逻辑）
+- `skills`：功能效果逻辑。
+- `attr`：道具属性或状态标签扩展。
+- `misc`：不归入主玩法的辅助机制（性能、显示、记录等）。
+
+---
+
+## 4) `include/pages/` 页面脚本层
+
+什么时候看：
+- 页面输出异常、重定向异常、页面级逻辑（非模块钩子）问题。
+
+关键：
+- `command_act.php`：动作执行回包。
+- `command_game.php`：游戏页初始化。
+- `command_valid.php`：入场与选卡页面逻辑。
+- `command_news/help/end/rank...`：各功能页。
+
+---
+
+## 5) `gamedata/`（必须按“源码/产物”分开看）
+
+### 源码/配置类（可读）
+- `gamedata/modules.list.php`：模块启用清单。
+- `gamedata/sql/`：数据库结构和重置脚本。
+
+### 编译产物（可删可再生）
+- `gamedata/modinit/`：模块 init 产物。
+- `gamedata/run/`：ADV2 预处理运行代码。
+- `gamedata/templates/`：模板编译产物。
+
+### 运行时（排障关注，不当源码读）
+- `gamedata/tmp/server/`：daemon 端口目录、busy/start_time 等。
+- `gamedata/tmp/response/`：socket 回包缓存。
+- `gamedata/tmp/playerlock/`：玩家锁。
+- `gamedata/tmp/news/`：news 刷新标记。
+- `gamedata/tmp/rooms/`：房间运行态。
+
+---
+
+## 6) `templates/default/`
+什么时候看：
+- UI 显示错位、按钮缺失、前端结构异常。
+
+注意：
+- 编辑这里是改“模板源码”；
+- 实际运行可能走 `gamedata/templates/*.tpl.php` 编译文件；
+- 若模板改了没生效，检查模板缓存与编译时间戳。
+
+## 新人最容易踩的坑
+- 把 `gamedata/run` 直接当手改源文件（会被重新生成覆盖）。
+- 只改 `templates/default`，没意识到编译缓存仍是旧版本。
+- 在 `extra` 修 bug 时忘了 `gametype` 分支条件，误伤标准模式。
+
+## 待确认
+- 某些历史 `gamedata/bak`/`gamedata/replays` 运维策略依赖外部清理脚本，需部署侧确认。

--- a/docs/04_ADD_NEW_MODE.md
+++ b/docs/04_ADD_NEW_MODE.md
@@ -1,0 +1,101 @@
+# 04_ADD_NEW_MODE｜新增模式 / gametype / instance 实战指南
+
+> 一句话摘要：先明确“只改规则（gtype）”还是“整包玩法（instance）”，再按注册、逻辑、配置、UI 四层落地。
+
+## 适合谁看
+- 想新增模式、改模式规则、做活动服的人。
+
+## 建议先读什么
+- `docs/02_MODULE_SYSTEM.md`
+- `include/modules/extra/instance/gtype1/main/main.php`
+- `include/modules/extra/instance/instance10_rogue/main.php`
+
+## 关键文件列表
+- `include/modules/core/sys/config/gamemode.config.php`
+- `include/modules/extra/instance/**`
+- `gamedata/modules.list.php`
+- （若涉及房间）`include/roommng/**`
+
+---
+
+## 1) `gtypeX` 与 `instanceX` 的关系（经验总结）
+
+### `gtypeX` 更像“规则补丁层”
+- 典型做法：在大量公共函数中 `if ($gametype == X)` 分支替换行为。
+- 例子：`gtype1/main` 修改选卡、NPC、商店、连斗、结算等。
+
+### `instanceX` 更像“完整玩法包”
+- 典型做法：附带专属 `config`、专属技能、甚至剧情/NPC链路。
+- 例子：`instance10_rogue` 除了规则替换，还带多技能（961~963 等）、商人/解锁流程。
+
+> 实务上两者可以叠加：同局既有 `gametype` 条件分支，也可加载 instance 模块。
+
+---
+
+## 2) 新增一个模式，最小需要改哪些文件
+
+### A. 注册层（必须）
+1. 新建模块目录：`include/modules/extra/instance/<your_mode>/`
+2. 写 `module.inc.php`（依赖、codelist、templatelist）
+3. 在 `gamedata/modules.list.php` 增加模块行并启用 `,1`
+
+### B. 逻辑层（必须）
+- 在 `main.php` 覆写你要接管的钩子函数，常见：
+  - `get_npclist()`
+  - `get_shopconfig()`
+  - `get_itemfilecont()/get_trapfilecont()`
+  - `checkcombo()`
+  - `check_addarea_gameover()`
+  - `rs_game()`
+
+### C. 配置层（常见）
+- `config/npc.data.config.php`
+- `config/shopitem.config.php`
+- `config/mapitem.config.php`
+- `config/stitem.config.php`、`stwep.config.php`
+
+### D. UI/模板层（可选）
+- 新增 `*.htm`，并在 `templatelist` 注册。
+
+---
+
+## 3) 三个现有模式对照
+
+## 3.1 低复杂度：`gtype5/main`
+特点：主要替换资源入口（npc/shop/mapitem/trap/stitem/stwep），逻辑改动较少。
+
+## 3.2 中复杂度：`gtype1/main`
+特点：
+- 改入场卡规则（强制卡 93）；
+- 改遭遇、隐蔽、组队行为；
+- 改结算与排名奖励；
+- 改 `prepare_new_game()` 触发条件。
+
+## 3.3 高复杂度：`instance10_rogue`
+特点：
+- 改选卡、初始道具、地图显示、商店机制；
+- 禁区节奏和结束条件重写；
+- 合成结果动态变异；
+- 配套大量专属技能与配置文件。
+
+---
+
+## 4) 新增模式 Checklist（可直接照抄）
+1. [ ] 明确模式编号（`gametype` 值）与适用房间。
+2. [ ] 新建模块并写 `module.inc.php`。
+3. [ ] 在 `main.php` 只覆写必要钩子，统一加 `if ($gametype==X)` 保护。
+4. [ ] 准备配置文件（npc/shop/mapitem/...）。
+5. [ ] 若有专属技能，新增 skill 模块并加入 modules.list。
+6. [ ] 若要改选卡，覆写 `card_validate_*` 或 `get_enter_battlefield_card`。
+7. [ ] 若要改胜负条件，覆写 `check_addarea_gameover` / 相关 gameover 流程。
+8. [ ] 更新文档和测试脚本。
+9. [ ] ADV/daemon 环境重新编译模块缓存。
+
+## 新人最容易踩的坑
+- 只改了 `gtype` 但忘了模式入口在哪里设置 `gametype`。
+- 配置文件路径写错（`__DIR__.'/config/...'` 最稳）。
+- 没在 `modules.list` 启用，代码永远不执行。
+- 忘记处理模式退出/结算路径，导致“能开不能收尾”。
+
+## 待确认
+- 部分房间模式切换逻辑位于房间管理模块，新增模式是否需要 UI 侧开放入口需人工联调确认。

--- a/docs/05_ADD_NEW_CARD.md
+++ b/docs/05_ADD_NEW_CARD.md
@@ -1,0 +1,130 @@
+# 05_ADD_NEW_CARD｜卡片系统与加卡流程
+
+> 一句话摘要：卡片以 `card.config.php` 为中心，入场时由 `cardbase::enter_battlefield_cardproc()` 将配置转成玩家初始数据/技能。
+
+## 适合谁看
+- 要新增卡片、改卡池、改选卡限制的人。
+
+## 建议先读什么
+1. `include/modules/extra/card/cardbase/config/card.config.php`
+2. `include/modules/extra/card/cardbase/main.php`
+3. `include/valid.func.php`
+
+## 关键文件列表
+- `cardbase/module.inc.php`
+- `cardbase/main.php`
+- `cardbase/config/card.config.php`
+- `include/pages/command_valid.php`
+- `include/valid.func.php`
+
+---
+
+## 1) `cardbase` 的职责边界
+- 管理卡片定义、卡包、稀有度、能量/CD。
+- 提供选卡可用性校验（`card_validate*`）。
+- 在入场时应用卡效果（`enter_battlefield_cardproc`）。
+- 管理“拥有卡数据”与 `card_data` 编码存储。
+
+不负责：
+- 具体技能行为细节（由 skill 模块实现）。
+
+---
+
+## 2) `card.config.php` 关键结构
+
+### 卡包与稀有度
+- `$packlist`, `$packdesc`, `$packstart`, `$packicon`
+- `$cardindex`（运行时可由 cache 覆盖）
+- `$card_rarecolor`, `$card_price`, 闪碎概率等
+
+### `$cards` 主体
+每张卡通常是：
+```php
+$id => [
+  'name' => ...,
+  'rare' => 'S/A/B/C/M',
+  'pack' => ...,
+  'energy' => ...,
+  'valid' => [...]
+]
+```
+
+### `valid` 常见字段
+- 直接属性：`att/def/hp/sp/lvl/...`
+- 装备/道具：`wep*`, `arb*`, `itm*`
+- `skills`：直接挂技能
+- `cardchange`：随机发动其他卡
+- `rand_sets`：随机套装（多组配置随机一组）
+- `rand_skills`：随机技能组
+- `gamevars`：修改全局游戏变量
+
+---
+
+## 3) 纯配置卡 vs 需要技能模块的卡
+
+### 纯配置卡（不新建技能）
+只改初始属性/道具/称号即可，例如：
+- 直接给武器、给数值、给固定 club。
+
+### 绑定技能卡（需要技能模块）
+卡效果涉及“回合中触发/战斗钩子/状态持续”，就应新建 skill 模块，再在 `valid.skills` 引用 skill id。
+
+---
+
+## 4) 入场链路（卡片如何生效）
+1. `command_valid.php` 选卡并做可用性检查。
+2. `enter_battlefield()`（`include/valid.func.php`）调用 `cardbase::get_enter_battlefield_card()`。
+3. `enter_battlefield_cardproc()` 读取卡 `valid`。
+4. `card_valid_info_process()` 把 `valid` 映射到玩家初始数据 + skills 列表。
+5. 玩家入库后，skillbase 处理技能获得。
+
+---
+
+## 5) 典型范例（仓库内）
+
+### 范例 A：纯数据卡
+如很多基础 C 卡：仅给道具/属性，不需要新模块。
+
+### 范例 B：绑定技能卡
+如带 `'skills' => ['731' => '0']` 的卡，依赖 `extra/card/skills/skill731`。
+
+### 范例 C：随机换卡卡
+如配置 `valid.cardchange` 的卡（按概率随机抽 S/A/B/C）。
+
+### 范例 D：模式专用卡
+如在某 gametype 下被强制选中（`gtype1` 强制 93，`instance10` 强制 1002）。
+
+---
+
+## 6) 卡池索引 / 缓存要不要更新
+- `card.config.php` 是源定义。
+- 运行时可能读 `gamedata/cache/card_index.config.php` 覆盖 `$cardindex`。
+- 若改了卡池或抽卡规则，需确认缓存是否需要重建（以及 modulemng 编译）。
+
+---
+
+## 7) 两套落地步骤
+
+### 7.1 新增一张简单卡（纯配置）
+1. 在 `$cards` 新增编号与定义。
+2. 设定 `pack`、`rare`、`energy`、`valid`。
+3. 若要可抽到，确认对应 rarity 的 index 生成逻辑。
+4. 验证 `card_validate` 下是否被当前模式禁用。
+5. 进场测试：看 `enter_battlefield_cardproc` 是否注入预期字段。
+
+### 7.2 新增一张复杂卡（独特效果）
+1. 先新建 `extra/card/skills/skillXXX/` 模块。
+2. 在 `module.inc.php` 声明依赖与模板。
+3. 在 `main.php` 实现钩子逻辑。
+4. `cards[id].valid.skills` 挂上 skill id。
+5. 若有随机/变卡逻辑，增加 `cardchange` / `rand_sets` / `rand_skills`。
+6. 加入 `gamedata/modules.list.php` 并重新编译。
+
+## 新人最容易踩的坑
+- 只改 `$cards`，忘了 skill 模块没启用。
+- `rand_skills` 下 `rnum`/数组索引写错，导致抽不到技能。
+- 以为 `cardindex` 手写生效，实际被 cache 覆盖。
+- 忘记模式禁卡逻辑（`card_validate_get_forbidden_cards` + 各 gtype 覆写）。
+
+## 待确认
+- 当前线上卡池索引重建流程是否全自动（与运营脚本有关，需部署侧确认）。

--- a/docs/06_ADD_NEW_SKILL.md
+++ b/docs/06_ADD_NEW_SKILL.md
@@ -1,0 +1,106 @@
+# 06_ADD_NEW_SKILL｜技能系统与加技能流程
+
+> 一句话摘要：技能是模块；技能 ID 是路由键；真正的触发时机由各上游模块钩子调用。
+
+## 适合谁看
+- 想新增/改技能（称号、卡片、实例技能）的人。
+
+## 建议先读什么
+1. `include/modules/base/skillbase/`（技能底层）
+2. 任意 skill 模块（如 `skill1`, `skill71`, `skill731`）
+3. `clubbase/main.php` / `cardbase/main.php`
+
+## 关键文件列表
+- `include/modules/base/skills/skill*/`
+- `include/modules/extra/card/skills/skill*/`
+- `include/modules/extra/club/skills/skill*/`
+- `include/modules/extra/instance/**/skill*/`
+- `gamedata/modules.list.php`
+
+---
+
+## 1) 技能模块分布规律
+- `base/skills`：基础通用技能。
+- `extra/card/skills`：卡片相关技能。
+- `extra/club/skills`：称号技能。
+- `extra/instance/.../skill*`：模式专属技能。
+
+## 2) 技能 ID 组织约定（观察结论）
+- 基础技能多为小号（1~几十）。
+- 称号、卡片、实例、活动逐渐占用更高段位。
+- 强约束来自模块命名：`skill731` 对应 namespace 与文件夹名都应一致。
+
+---
+
+## 3) 一个新技能通常需要哪些文件
+最小集：
+- `module.inc.php`
+- `main.php`
+
+常见附加：
+- `desc.htm`（技能描述）
+- `profilecmd.htm` / `battlecmd_desc.htm`（UI）
+- `config/*.php`（复杂参数）
+
+---
+
+## 4) 如何被外部引用
+
+### 从卡片引用
+在 `card.config.php`：
+```php
+'valid' => ['skills' => ['731' => '0']]
+```
+
+### 从称号引用
+`clubbase` 给称号时会遍历 `clublist[club]['skills']` 并 `skill_acquire`。
+
+### 从模式/道具引用
+在 `main.php` 中调用 `skill_acquire/skill_setvalue`，或在卡/道具效果里写入 skill 列表。
+
+---
+
+## 5) 技能参数传递方式
+- 常量信息：`define('MOD_SKILLXXX_INFO','club;battle;...')`
+- 动态值：`skill_setvalue($id, $key, $val, $pa)`
+- 查询：`skill_query`, `skill_getvalue`
+- 复杂状态：可用 `gencode/gdecode` 序列化结构（如交易记录、多层数组）
+
+---
+
+## 6) 三种风格技能对比
+
+### A. 简单被动：`skill1`
+- 结构简洁；
+- 主要覆写若干计算函数；
+- 无复杂 UI/状态。
+
+### B. 主动战斗技：`skill71`
+- 含怒气消耗、解锁判定、战斗前准备；
+- 改伤害倍率并写 news；
+- 在 `clubbase` 战斗技入口中被调用。
+
+### C. 复杂交互技：`skill731`
+- 含市场状态、全局 `gamevars`、买卖操作、库存与价格更新；
+- 含界面模板和记录序列化；
+- 体现“技能可承载系统级玩法”。
+
+---
+
+## 7) 新增技能 Checklist
+1. [ ] 选定未冲突 skill id。
+2. [ ] 新建 `skillXXX/module.inc.php + main.php`。
+3. [ ] 每个可覆写函数开头加 `__MAGIC__`。
+4. [ ] `init()` 内注册技能名与信息。
+5. [ ] 接入触发源（卡/称号/模式/道具）。
+6. [ ] 如需 UI，补 `desc/profilecmd` 并加到 `templatelist`。
+7. [ ] 加入 `gamedata/modules.list.php`。
+8. [ ] 编译并验证：获取技能、触发技能、保存/重载后状态正确。
+
+## 新人最容易踩的坑
+- 只写了技能模块，没挂接到任何入口，导致“永远不触发”。
+- 参数存进 `$pa` 临时数组却没通过 `player_save` 持久化。
+- 忘记在非当前玩家对象上调用时传 `$pa`，误改了 `$sdata`。
+
+## 待确认
+- 个别历史技能仍依赖旧式字段编码，建议逐个验证存档兼容性。

--- a/docs/07_ADD_NEW_MECHANIC.md
+++ b/docs/07_ADD_NEW_MECHANIC.md
@@ -1,0 +1,95 @@
+# 07_ADD_NEW_MECHANIC｜新增“跨模块机制”的方法
+
+> 一句话摘要：新机制优先做成独立模块，通过钩子串联 battle/item/map/player/UI，避免把逻辑散落在旧模块里。
+
+## 适合谁看
+- 要做新玩法系统（非单卡/单技能）的开发者。
+
+## 建议先读什么
+- `docs/02_MODULE_SYSTEM.md`
+- `docs/04_ADD_NEW_MODE.md`
+- 本文案例章节
+
+## 关键文件列表
+- `include/modules/extra/card/cardbase/main.php`
+- `include/modules/extra/club/clubbase/main.php`
+- `include/modules/extra/instance/instance10_rogue/main.php`
+- `include/modules/core/sys/gamectl.php`
+
+---
+
+## 1) 什么时候该新建模块，而不是塞进旧模块
+建议新建模块的信号：
+1. 需要跨 2 个以上子系统（如战斗 + 道具 + UI）。
+2. 机制只在某些模式生效，不应污染所有模式。
+3. 需要独立配置与后续迭代空间。
+4. 需要开关化（能在 `modules.list` 启停）。
+
+反例：
+- 只改一个数值常量，且仅本模块使用，不必新建模块。
+
+---
+
+## 2) 跨模块机制剖析（现有案例）
+
+### 案例 A：卡片机制（`cardbase`）
+跨越：
+- 入场流程（`valid.func.php`）
+- 用户数据（`card_data` 编码）
+- 模式禁卡（`card_validate_*` + gtype 覆写）
+- 技能系统（`skills` 注入）
+
+为什么是独立模块：
+- 涉及规则、资源、UI、存储、模式兼容，耦合面太广。
+
+### 案例 B：肉鸽机制（`instance10_rogue`）
+跨越：
+- 地图可见性与区域颜色
+- 商店入口替换
+- 合成结果变异
+- 开局资源/NPC/结局判定
+- 卡片强制策略
+
+为什么合理：
+- 通过 `if ($gametype==20)` 收口在一个 instance 模块，避免污染基础玩法。
+
+---
+
+## 3) 推荐决策流程（新增机制）
+
+### Step 1：先找可挂钩函数
+先在以下关键词搜：
+- `act`, `strike_prepare`, `itemmix_success`, `check_addarea_gameover`, `parse_interface_*`, `get_*config`。
+
+### Step 2：判断挂在哪层
+- 涉及全局流程与 gameinfo：偏 `core`/`sys`。
+- 常规玩法共享：偏 `base`。
+- 特定模式/活动：偏 `extra`（推荐）。
+
+### Step 3：确定边界
+- 规则判定放机制模块；
+- 资源表放 `config/*.php`；
+- 展示放 `*.htm`；
+- 模式判断统一收口，不要散落多个 unrelated 模块。
+
+### Step 4：落地顺序
+1. 空模块 + `module.inc.php`
+2. 最小钩子闭环（能跑）
+3. 配置拆分
+4. UI 与日志
+5. 调优与兼容
+
+---
+
+## 4) 如何避免逻辑散落
+- 所有 `if($gametype==X)` 尽量集中在同一机制模块（或同一目录族）。
+- 明确“单一数据源”：不要同一状态既写 `$gamevars` 又写临时全局再写 DB。
+- 给机制建一个“主入口函数”（例如 `mechanicX_process()`）供多处调用。
+
+## 新人最容易踩的坑
+- 先到处补丁，最后自己都找不到机制入口。
+- 忽略 `save_gameinfo()/player_save()`，导致状态只在当前请求有效。
+- UI 逻辑直接写在主流程，不可复用且难测。
+
+## 待确认
+- 某些旧机制是否仍依赖历史页面脚本短路分支，建议在联调中补全调用链图。

--- a/docs/08_DEBUGGING_GUIDE.md
+++ b/docs/08_DEBUGGING_GUIDE.md
@@ -1,0 +1,130 @@
+# 08_DEBUGGING_GUIDE｜排错与修 BUG 指南
+
+> 一句话摘要：先判断故障层（入口/模块/配置/daemon），再看对应目录，最后才怀疑业务逻辑本身。
+
+## 适合谁看
+- 接盘修线上 bug 的维护者。
+
+## 建议先读什么
+- `docs/01_RUNTIME_FLOW.md`
+- `docs/03_DIRECTORY_MAP.md`
+
+## 关键文件列表
+- `command.php`
+- `include/common.inc.php`
+- `include/pages/command_act.php`
+- `include/modules/core/sys/*`
+- `gamedata/tmp/server/*`
+
+---
+
+## 1) 第一轮分诊：四层法
+
+## A. 入口层问题（请求没进业务）
+看：
+- `command.php` 分支是否命中。
+- `$page/$mode/$command` 是否正确。
+- 是否被 `redirect:` 或 `gexit()` 提前返回。
+
+## B. 模块层问题（逻辑没按预期）
+看：
+- 同名函数链是否被其他模块覆盖。
+- `modules.list.php` 顺序与启用状态。
+- 目标模块是否真的在链上（`MOD_XXX`）。
+
+## C. 配置层问题（逻辑对，但数据错）
+看：
+- `config/*.php` 是否与模式匹配。
+- 选卡/技能/道具配置是否被模式禁用。
+- 样本配置与本地真实配置是否一致。
+
+## D. daemon 层问题（业务像错，实际是进程通信错）
+看：
+- `gamedata/tmp/server/<port>/busy/start_time/worknum`。
+- 是否存在“无可用进程 / 进程异常 / 回包文件缺失”。
+- 日志级别是否允许输出足够信息。
+
+---
+
+## 2) “这是业务 bug 还是 daemon bug”快速判断
+
+### 高概率 daemon 问题特征
+- 同一请求偶发失败、重试又好。
+- 页面空白或拿到旧回包。
+- `command.php` client 日志显示找不到可用 server。
+- `busy` 文件长期不消失。
+
+### 高概率业务问题特征
+- 特定模式/特定技能必现。
+- 关闭 daemon 后仍稳定复现。
+- 数据库状态与预期逻辑持续偏离。
+
+---
+
+## 3) 各类异常优先看哪里
+
+## 页面显示异常
+1. `include/pages/command_*.php`
+2. 对应模块 `parse_interface_*` / `prepare_response_content`
+3. `templates/default/*.htm`
+4. `gamedata/templates/*.tpl.php`（确认是否编译旧缓存）
+
+## 玩家数据异常
+1. `core/player/main.php`（fetch/load/save/锁）
+2. `valid.func.php`（入场初始）
+3. `core/sys/gamectl.php`（gameover/reset）
+
+## 战斗/技能/卡片异常
+1. `base/battle`, `base/attack`, `skillbase`
+2. 对应 `skillXXX/main.php`
+3. `cardbase/main.php` + `card.config.php`
+
+## 模式异常
+1. 对应 `gtypeX/main.php` 或 `instanceX/main.php`
+2. `gamemode.config.php`
+3. 该模式专属 `config/*.php`
+
+---
+
+## 4) 缓存/临时文件处理建议
+
+### 运行时产物（可清理，谨慎）
+- `gamedata/tmp/*`：锁、socket、回包、房间状态。
+- `gamedata/run/*`、`gamedata/modinit/*`：ADV 产物（可重建）。
+- `gamedata/templates/*`：模板编译产物。
+
+### 不应作为源码阅读重点
+- `gamedata/tmp`
+- `gamedata/cache`（除非排缓存问题）
+
+---
+
+## 5) 常见“伪业务 bug”场景
+1. **改模块后无效**：未重新编译 ADV 产物。
+2. **模式逻辑错乱**：daemon 驻留进程尚未重载到新代码。
+3. **选卡异常**：`card_validate` 与 gtype 强制禁卡叠加。
+4. **房间状态异常**：`roomvars`/room 文件与 game 表不同步。
+5. **并发复活/状态错位**：玩家锁/进程锁释放异常。
+
+---
+
+## 6) 推荐排障顺序（可贴工单）
+1. 记录复现步骤 + `gametype/roomid/command`。
+2. 判定是否 daemon 模式。
+3. 看 `command.php` 实际命中分支。
+4. 看目标函数的模块链覆盖顺序。
+5. 验证关键状态是否持久化（DB/gamevars/player_save）。
+6. 必要时清理运行时产物并重编译后复测。
+
+## 具体示例
+- 现象：玩家点击按钮后偶发“无响应”，刷新后恢复。  
+  先看 `gamedata/tmp/server/*/busy` 是否长期存在，再看 `command.php` client 分支是否选到可用进程。
+- 现象：某技能仅在特定模式异常。  
+  先查 `skillXXX/main.php`，再查对应 `gtype/instance` 是否覆写了同名钩子导致行为变化。
+
+## 新人最容易踩的坑
+- 一上来就改业务逻辑，不先判断 daemon/缓存状态。
+- 看到报错就改 `include/modules`，但实际运行代码来自 `gamedata/run` 旧产物。
+
+## 待确认
+- 线上日志收集方式（文件/外部系统）在仓库内未统一体现，建议运维侧补一份 SOP。

--- a/docs/09_LLM_ONBOARDING.md
+++ b/docs/09_LLM_ONBOARDING.md
@@ -1,0 +1,81 @@
+# 09_LLM_ONBOARDING｜给后续 AI 助手的高密度上手说明
+
+> 一句话摘要：这个仓库是“模块链 + daemon 转发 + 编译产物”的系统，不是普通 include 单体。
+
+## 适合谁看
+- 后续接手本仓库的 LLM / Agent。
+
+## 建议先读什么（严格顺序）
+1. `command.php`
+2. `include/common.inc.php`
+3. `include/modules/modules.func.php`
+4. `gamedata/modules.list.php`
+5. `include/pages/command_act.php`
+6. `include/modules/extra/card/cardbase/{main.php,config/card.config.php}`
+7. 目标模式目录（`extra/instance/...`）
+
+## 关键文件列表
+- 模块装配：`gamedata/modules.list.php`
+- 模块运行机制：`include/modules/modules.func.php`
+- 入场与卡片：`include/valid.func.php`, `command_valid.php`
+- 请求主链：`command.php`, `common.inc.php`
+
+---
+
+## 给 AI 的硬规则
+1. 搜函数时默认“同名多实现”，不要只看第一处命中。
+2. 看到 `$chprocess(...)` 说明在钩子链中，必须追踪上下游。
+3. 改模块后若无效，优先怀疑 ADV/daemon 缓存，而非代码没执行。
+4. `gamedata/tmp` 是运行态，不是业务源码。
+5. `config.sample.php` 不是线上实际值，真实配置可能在被忽略文件里。
+
+---
+
+## 任务类型 → 首查位置
+
+### 新卡片
+1. `card.config.php` 的 `$cards`
+2. `cardbase::card_valid_info_process`
+3. `card_validate*`
+4. `valid.func.php::enter_battlefield`
+5. 对应 `skillXXX` 模块（若有）
+
+### 新技能
+1. 选择目录（base/card/club/instance）
+2. 新建 `skillXXX/{module.inc.php,main.php}`
+3. 接入触发源（card/club/mode/item）
+4. 确认 skillbase 参数读写
+5. modules.list 启用
+
+### 新模式
+1. 选择 `gtypeX` or `instanceX`
+2. 覆写 `get_*config/checkcombo/check_addarea_gameover/rs_game`
+3. 加配置文件
+4. 注册模块
+5. 测试结算路径
+
+### 修 BUG
+1. 判入口层 or daemon层
+2. 判模块链覆盖
+3. 判配置数据
+4. 判持久化（save_gameinfo/player_save）
+5. 清理缓存并重编译复测
+
+---
+
+## 常见误区（AI 高发）
+- 把 `gamedata/run` 改成“源文件”。
+- 忽略 `gametype` 条件，导致全模式被改。
+- 在 daemon 模式下输出调试文本破坏回包协议。
+- 只改 `module.inc.php` 不更新 `modules.list`。
+
+## 具体示例
+- 任务“新增卡片技能”：若只改 `card.config.php` 而没启用 `skillXXX` 模块，入场时会拿不到行为效果。
+- 任务“修复某模式商店异常”：先查 `gtype/instance` 对 `get_shopconfig()` 的覆写，而不是先改 `base/itemshop`。
+
+## 新人最容易踩的坑
+- AI 只依据目录名推断，不跟踪 `modules.list` 实际启用情况。
+- AI 忽略 `$chprocess()` 导致误判调用顺序。
+
+## 待确认
+- 当前部署是否强制 daemon 常驻与自动拉起（需看运维脚本/进程管理）。

--- a/docs/10_MAINTAINER_CHEATSHEET.md
+++ b/docs/10_MAINTAINER_CHEATSHEET.md
@@ -1,0 +1,54 @@
+# 10_MAINTAINER_CHEATSHEET｜维护者速查表
+
+> 一句话摘要：改什么就先看哪 5 个位置。
+
+## 适合谁看
+- 已经熟悉项目，想快速开工的人。
+
+## 建议先读什么
+- `docs/00_START_HERE.md`
+
+## 关键文件列表
+- `command.php`
+- `include/common.inc.php`
+- `include/valid.func.php`
+- `include/modules/extra/card/cardbase/*`
+- `include/modules/extra/instance/*`
+
+## 新卡片：先看这 5 个位置
+1. `include/modules/extra/card/cardbase/config/card.config.php`
+2. `include/modules/extra/card/cardbase/main.php`（`enter_battlefield_cardproc`）
+3. `include/modules/extra/card/cardbase/main.php`（`card_validate*`）
+4. `include/pages/command_valid.php`
+5. `include/valid.func.php`
+
+## 新技能：先看这 5 个位置
+1. 目标目录的 `skillXXX/module.inc.php`
+2. 目标目录的 `skillXXX/main.php`
+3. `include/modules/base/skillbase/*`
+4. 挂接点（`cardbase`/`clubbase`/instance）
+5. `gamedata/modules.list.php`
+
+## 新模式：先看这 5 个位置
+1. `include/modules/extra/instance/gtype1/main/main.php`（参考）
+2. `include/modules/extra/instance/instance10_rogue/main.php`（复杂参考）
+3. `include/modules/core/sys/config/gamemode.config.php`
+4. 你的新模块 `module.inc.php + main.php`
+5. `gamedata/modules.list.php`
+
+## 修 BUG：先看这 5 个位置
+1. `command.php`
+2. `include/common.inc.php`
+3. `include/pages/command_act.php`（或对应页面脚本）
+4. 对应业务模块 `main.php`
+5. `gamedata/tmp/server`（daemon 状态）
+
+## 具体示例
+- “新增卡片失败”排查：先确认 `card.config.php` 写入正确，再看 `card_validate` 是否被当前模式禁用，最后看对应技能模块是否启用。
+
+## 新人最容易踩的坑
+- 看错目录层（把运行时产物当源码）。
+- 忘记重编译模块缓存。
+
+## 待确认
+- 若线上使用自定义部署脚本，以上路径可能有镜像副本，需运维确认。

--- a/docs/LLM_ONBOARDING.md
+++ b/docs/LLM_ONBOARDING.md
@@ -1,0 +1,5 @@
+# LLM_ONBOARDING
+
+本文件为 `docs/09_LLM_ONBOARDING.md` 的别名入口，请优先阅读：
+
+- [09_LLM_ONBOARDING.md](./09_LLM_ONBOARDING.md)

--- a/readme.md
+++ b/readme.md
@@ -23,6 +23,22 @@
 - 能将模块化源代码自动编译为高效执行代码的模块化引擎，兼顾代码组织、多人协作和运行效率优化
 - 基于socket的驻留daemon，支持Linux和WIN
 
+## 维护文档入口（Onboarding / 维护手册）
+
+> 面向新维护者与 AI 助手的仓库文档索引：
+
+- [00_START_HERE](./docs/00_START_HERE.md)
+- [01_RUNTIME_FLOW](./docs/01_RUNTIME_FLOW.md)
+- [02_MODULE_SYSTEM](./docs/02_MODULE_SYSTEM.md)
+- [03_DIRECTORY_MAP](./docs/03_DIRECTORY_MAP.md)
+- [04_ADD_NEW_MODE](./docs/04_ADD_NEW_MODE.md)
+- [05_ADD_NEW_CARD](./docs/05_ADD_NEW_CARD.md)
+- [06_ADD_NEW_SKILL](./docs/06_ADD_NEW_SKILL.md)
+- [07_ADD_NEW_MECHANIC](./docs/07_ADD_NEW_MECHANIC.md)
+- [08_DEBUGGING_GUIDE](./docs/08_DEBUGGING_GUIDE.md)
+- [09_LLM_ONBOARDING](./docs/09_LLM_ONBOARDING.md)
+- [10_MAINTAINER_CHEATSHEET](./docs/10_MAINTAINER_CHEATSHEET.md)
+
 ## 部署指南
 
 0. 环境要求：php 7.0以上，推荐8.0以上（测试稳定的最高版本为8.2.9）。必须开启curl和socket两项扩展。必须支持本地对本地php文件的http访问，并准备一个不需经过dns解析的本地文件地址（类似于`http://127.0.0.1/dts`）。php进程内存限制最少需要有256M。建议将php进程内存限制修改为512M或更高，将php最大执行时间修改为180秒或更高，将php.ini中`output_buffering`一项打开（一般设为`output_buffering = 4096`）。


### PR DESCRIPTION
### Motivation
- 为 Unstable 分支补齐一套面向新人与 LLM 的中文维护/入门文档，聚焦模块化运行时模型、daemon/socket 驻留机制、模块系统、卡片/技能/模式的落地路径与实操清单。  
- 目标是让有 PHP 基础但不熟悉本分支结构的维护者，能在 1~2 小时内建立可执行心智模型并快速定位改动点。  
- 文档同时用于降低 AI/agent 误判仓库结构（避免把运行产物误作源码）的风险。  

### Description
- 新增完整文档集（放在 `docs/`）：`00_START_HERE.md`, `01_RUNTIME_FLOW.md`, `02_MODULE_SYSTEM.md`, `03_DIRECTORY_MAP.md`, `04_ADD_NEW_MODE.md`, `05_ADD_NEW_CARD.md`, `06_ADD_NEW_SKILL.md`, `07_ADD_NEW_MECHANIC.md`, `08_DEBUGGING_GUIDE.md`, `09_LLM_ONBOARDING.md`, `10_MAINTAINER_CHEATSHEET.md`，并增加别名 `docs/LLM_ONBOARDING.md`。  
- 每篇文档均包含：一句话摘要、适合读者、建议先读哪些文件、关键文件列表、具体示例、最容易踩的坑、以及“待确认”项（无法仅靠仓库静读确定的部署细节）。  
- 在根 README（`readme.md`）中新增“维护文档入口（Onboarding / 维护手册）”区块，显著列出以上文档链接以便新人与自动化 agent 快速进入阅读路径。  
- 文档内容以仓库真实实现为例（引用 `command.php`、`include/common.inc.php`、`include/modules/modules.func.php`、`gamedata/modules.list.php`、`include/modules/extra/card/*`、`include/valid.func.php`、各 gtype/instance 等文件路径），并对模块加载、`__MAGIC__`/`$chprocess` 钩子链、ADV 编译产物与 daemon 运行时产物做了明确区分与操作建议。  

### Testing
- 运行 `git diff --check`（静态检查）以确认未引入拼写/空白冲突，结果通过。  
- 使用 `git status` / 添加并 `git commit` 完成本次文档变更的提交，提交成功（提交信息："docs: add comprehensive onboarding and maintenance guides for unstable branch"）。  
- 已检查新增文档文件列表在版本库中存在且已被提交，且 README 的链接区块已被更新；本次变更为文档-only，无业务代码改动，因此不涉及运行时测试。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ded8c7bbcc83268776b3f84b86618c)